### PR TITLE
Fix filename typo for testing with locus

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ pip install locust
 ```
 
 ```
-locust -f locust.py --headless --users 10 --spawn-rate 1 -H http://localhost:5002
+locust -f locustfile.py --headless --users 10 --spawn-rate 1 -H http://localhost:5002
 ```
 
 


### PR DESCRIPTION
There was a typo in README in "Send Traffic with Locust" section